### PR TITLE
fix: disallow bool as object value

### DIFF
--- a/src/yarrrml-json-schema.json
+++ b/src/yarrrml-json-schema.json
@@ -273,7 +273,6 @@
 			"oneOf": [
 				{ "type": "string" },
 				{ "type": "number" },
-				{ "type": "boolean" },
 				{
 					"type": "array",
 					"minLength": 2,


### PR DESCRIPTION
This lead to errors like: `mapping "...": po with predicate(s) "sdo:valueAddedTaxIncluded" does not have an object defined. Skipping.