### PR TITLE
fix: Rename title from YARRML to YARRRML

### DIFF
--- a/src/yarrrml-json-schema.json
+++ b/src/yarrrml-json-schema.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema",
 	"$comment": "Abbreviations are kept next to their full equivalents, with a $ref to that equivalent.",
-	"title": "YARRML (RML in YAML)",
+	"title": "YARRRML (RML in YAML)",
 	"type": "object",
 	"allOf": [{ "$ref": "#/definitions/IDocument" }],
 	"definitions": {


### PR DESCRIPTION
Kinda embarrassing honestly to have had `YARRML` typo in the schema's title 🙃